### PR TITLE
Refactoring and bug fixes in player and spectator handling

### DIFF
--- a/controller/src/enhancements/player.rs
+++ b/controller/src/enhancements/player.rs
@@ -12,6 +12,7 @@ use cs2::{
 use cs2_schema_generated::{
     cs2::client::{
         CCSPlayerController,
+        C_BaseEntity,
         C_CSPlayerPawn,
     },
     EntityHandle,
@@ -40,7 +41,6 @@ pub struct PlayerESP {
     toggle: KeyToggle,
     players: Vec<PlayerPawnInfo>,
     local_team_id: u8,
-    local_pos: Option<nalgebra::Vector3<f32>>,
 }
 
 impl PlayerESP {
@@ -49,7 +49,6 @@ impl PlayerESP {
             toggle: KeyToggle::new(),
             players: Default::default(),
             local_team_id: 0,
-            local_pos: Default::default(),
         }
     }
 
@@ -181,31 +180,36 @@ impl Enhancement for PlayerESP {
         self.players.reserve(16);
 
         let view_target = ctx.states.resolve::<LocalCameraControllerTarget>(())?;
-        let target_controller_id = match &view_target.target_controller_entity_id {
+        let target_entity_id = match &view_target.target_entity_id {
             Some(value) => *value,
             None => return Ok(()),
         };
+        let target_entity_identity = entities
+            .get_by_handle::<C_BaseEntity>(&EntityHandle::from_index(target_entity_id))?
+            .context("missing current target entity")?;
+        let target_entity_class =
+            class_name_cache.lookup(&target_entity_identity.entity_class_info()?)?;
+        if target_entity_class
+            .map(|name| *name == "C_CSPlayerPawn")
+            .unwrap_or(false)
+        {
+            let target_player_pawn = target_entity_identity
+                .entity()?
+                .cast::<C_CSPlayerPawn>()
+                .reference_schema()?;
 
-        let local_player_controller = entities
-            .get_by_handle::<CCSPlayerController>(&EntityHandle::from_index(target_controller_id))?
-            .context("missing current player controller")?
-            .entity()?
-            .reference_schema()?;
+            let target_player_controller = entities
+                .get_by_handle(&target_player_pawn.m_hController()?)?
+                .context("missing current player controller")?
+                .entity()?
+                .cast::<CCSPlayerController>()
+                .reference_schema()?;
 
-        let local_player_pawn_entity_index =
-            local_player_controller.m_hPlayerPawn()?.get_entity_index();
-        self.local_team_id = local_player_controller.m_iPendingTeamNum()?;
+            self.local_team_id = target_player_controller.m_iPendingTeamNum()?;
+        }
 
         for entity_identity in entities.all_identities() {
-            if entity_identity.handle::<()>()?.get_entity_index() == local_player_pawn_entity_index
-            {
-                /* current pawn we control/observe */
-                let local_pawn = entity_identity
-                    .entity_ptr::<C_CSPlayerPawn>()?
-                    .read_schema()?;
-                let local_pos =
-                    nalgebra::Vector3::<f32>::from_column_slice(&local_pawn.m_vOldOrigin()?);
-                self.local_pos = Some(local_pos);
+            if entity_identity.handle::<()>()?.get_entity_index() == target_entity_id {
                 continue;
             }
 
@@ -247,20 +251,13 @@ impl Enhancement for PlayerESP {
         let draw = ui.get_window_draw_list();
         const UNITS_TO_METERS: f32 = 0.01905;
 
-        match (view.get_view_world_position(), self.local_pos) {
-            (Some(view_world_position), Some(local_pos)) => {
-                log::info!("view: {}", view_world_position);
-                log::info!("pos: {}", local_pos);
-            },
-            _ => return Ok(())
-        }
+        let view_world_position = match view.get_view_world_position() {
+            Some(view_world_position) => view_world_position,
+            _ => return Ok(()),
+        };
+
         for entry in self.players.iter() {
-            let distance = if let Some(local_pos) = self.local_pos {
-                let distance = (entry.position - local_pos).norm() * UNITS_TO_METERS;
-                distance
-            } else {
-                0.0
-            };
+            let distance = (entry.position - view_world_position).norm() * UNITS_TO_METERS;
             let esp_settings = match self.resolve_esp_player_config(&settings, entry) {
                 Some(settings) => settings,
                 None => continue,

--- a/controller/src/enhancements/player.rs
+++ b/controller/src/enhancements/player.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use cs2::{
     BoneFlags,
     CEntityIdentityEx,
@@ -9,14 +8,7 @@ use cs2::{
     PlayerPawnInfo,
     PlayerPawnState,
 };
-use cs2_schema_generated::{
-    cs2::client::{
-        CCSPlayerController,
-        C_BaseEntity,
-        C_CSPlayerPawn,
-    },
-    EntityHandle,
-};
+use cs2_schema_generated::cs2::client::C_CSPlayerPawn;
 use imgui::ImColor32;
 use obfstr::obfstr;
 

--- a/controller/src/enhancements/player.rs
+++ b/controller/src/enhancements/player.rs
@@ -246,6 +246,14 @@ impl Enhancement for PlayerESP {
 
         let draw = ui.get_window_draw_list();
         const UNITS_TO_METERS: f32 = 0.01905;
+
+        match (view.get_view_world_position(), self.local_pos) {
+            (Some(view_world_position), Some(local_pos)) => {
+                log::info!("view: {}", view_world_position);
+                log::info!("pos: {}", local_pos);
+            },
+            _ => return Ok(())
+        }
         for entry in self.players.iter() {
             let distance = if let Some(local_pos) = self.local_pos {
                 let distance = (entry.position - local_pos).norm() * UNITS_TO_METERS;

--- a/controller/src/enhancements/player.rs
+++ b/controller/src/enhancements/player.rs
@@ -194,9 +194,7 @@ impl Enhancement for PlayerESP {
         };
 
         for entity_identity in entities.all_identities() {
-            if entity_identity.handle::<()>()?.value
-                == target_entity_handle_index
-            {
+            if entity_identity.handle::<()>()?.value == target_entity_handle_index {
                 continue;
             }
 

--- a/controller/src/enhancements/player.rs
+++ b/controller/src/enhancements/player.rs
@@ -184,8 +184,9 @@ impl Enhancement for PlayerESP {
             Some(value) => *value,
             None => return Ok(()),
         };
+        let target_entity_handle = EntityHandle::from_index(target_entity_id);
         let target_entity_identity = entities
-            .get_by_handle::<C_BaseEntity>(&EntityHandle::from_index(target_entity_id))?
+            .get_by_handle::<C_BaseEntity>(&target_entity_handle)?
             .context("missing current target entity")?;
         let target_entity_class =
             class_name_cache.lookup(&target_entity_identity.entity_class_info()?)?;
@@ -209,7 +210,9 @@ impl Enhancement for PlayerESP {
         }
 
         for entity_identity in entities.all_identities() {
-            if entity_identity.handle::<()>()?.get_entity_index() == target_entity_id {
+            if entity_identity.handle::<()>()?.get_entity_index()
+                == target_entity_handle.get_entity_index()
+            {
                 continue;
             }
 

--- a/controller/src/enhancements/player.rs
+++ b/controller/src/enhancements/player.rs
@@ -180,7 +180,7 @@ impl Enhancement for PlayerESP {
         self.players.reserve(16);
 
         let view_target = ctx.states.resolve::<LocalCameraControllerTarget>(())?;
-        let target_entity_id = match &view_target.target_entity_id {
+        let target_entity_id = match &view_target.target_entity_handle_index {
             Some(value) => *value,
             None => return Ok(()),
         };
@@ -200,7 +200,7 @@ impl Enhancement for PlayerESP {
                 .reference_schema()?;
 
             let target_player_controller = entities
-                .get_by_handle(&target_player_pawn.m_hController()?)?
+                .get_by_handle(&target_player_pawn.m_hOriginalController()?)?
                 .context("missing current player controller")?
                 .entity()?
                 .cast::<CCSPlayerController>()

--- a/controller/src/enhancements/spectators_list.rs
+++ b/controller/src/enhancements/spectators_list.rs
@@ -25,11 +25,11 @@ impl Enhancement for SpectatorsListIndicator {
         }
 
         let view_target = states.resolve::<LocalCameraControllerTarget>(())?;
-        let target_controller_id = match &view_target.target_controller_entity_id {
+        let target_entity_id = match &view_target.target_entity_id {
             Some(value) => *value,
             None => return Ok(()),
         };
-        let spectators = states.resolve::<SpectatorList>(target_controller_id)?;
+        let spectators = states.resolve::<SpectatorList>(target_entity_id)?;
 
         let group = ui.begin_group();
 

--- a/controller/src/enhancements/spectators_list.rs
+++ b/controller/src/enhancements/spectators_list.rs
@@ -25,11 +25,11 @@ impl Enhancement for SpectatorsListIndicator {
         }
 
         let view_target = states.resolve::<LocalCameraControllerTarget>(())?;
-        let target_entity_id = match &view_target.target_entity_id {
+        let target_entity_handle_index = match &view_target.target_entity_handle_index {
             Some(value) => *value,
             None => return Ok(()),
         };
-        let spectators = states.resolve::<SpectatorList>(target_entity_id)?;
+        let spectators = states.resolve::<SpectatorList>(target_entity_handle_index)?;
 
         let group = ui.begin_group();
 

--- a/controller/src/view/world.rs
+++ b/controller/src/view/world.rs
@@ -66,7 +66,7 @@ impl ViewController {
         let y = (b * view_matrix.m41 + e * view_matrix.m42 + h * view_matrix.m43) / z;
         let z = (c * view_matrix.m41 + f * view_matrix.m42 + k * view_matrix.m43) / z;
 
-        Some(nalgebra::Vector3::new(x, y, z))
+        Some(nalgebra::Vector3::new(-x, -y, -z))
     }
 
     /// Returning an mint::Vector2<f32> as the result should be used via ImGui.

--- a/controller/src/view/world.rs
+++ b/controller/src/view/world.rs
@@ -44,6 +44,31 @@ impl ViewController {
         self.screen_bounds = bounds;
     }
 
+    pub fn get_view_world_position(&self) -> Option<nalgebra::Vector3<f32>> {
+        let view_matrix = self.view_matrix;
+        let a = view_matrix.m22 * view_matrix.m33 - view_matrix.m32 * view_matrix.m23;
+        let b = view_matrix.m32 * view_matrix.m13 - view_matrix.m12 * view_matrix.m33;
+        let c = view_matrix.m12 * view_matrix.m23 - view_matrix.m22 * view_matrix.m13;
+        let z = view_matrix.m11 * a + view_matrix.m21 * b + view_matrix.m31 * c;
+
+        if z.abs() < 0.0001 {
+            return None;
+        }
+
+        let d = view_matrix.m31 * view_matrix.m23 - view_matrix.m21 * view_matrix.m33;
+        let e = view_matrix.m11 * view_matrix.m33 - view_matrix.m31 * view_matrix.m13;
+        let f = view_matrix.m21 * view_matrix.m13 - view_matrix.m11 * view_matrix.m23;
+        let g = view_matrix.m21 * view_matrix.m32 - view_matrix.m31 * view_matrix.m22;
+        let h = view_matrix.m31 * view_matrix.m12 - view_matrix.m11 * view_matrix.m32;
+        let k = view_matrix.m11 * view_matrix.m22 - view_matrix.m21 * view_matrix.m12;
+
+        let x = (a * view_matrix.m41 + d * view_matrix.m42 + g * view_matrix.m43) / z;
+        let y = (b * view_matrix.m41 + e * view_matrix.m42 + h * view_matrix.m43) / z;
+        let z = (c * view_matrix.m41 + f * view_matrix.m42 + k * view_matrix.m43) / z;
+
+        Some(nalgebra::Vector3::new(x, y, z))
+    }
+
     /// Returning an mint::Vector2<f32> as the result should be used via ImGui.
     pub fn world_to_screen(
         &self,

--- a/cs2/src/state/observer.rs
+++ b/cs2/src/state/observer.rs
@@ -1,10 +1,7 @@
 use std::ffi::CStr;
 
 use anyhow::Context;
-use cs2_schema_generated::cs2::client::{
-    C_CSObserverPawn,
-    C_CSPlayerPawnBase,
-};
+use cs2_schema_generated::cs2::client::C_CSObserverPawn;
 use obfstr::obfstr;
 use utils_state::{
     State,
@@ -52,8 +49,8 @@ impl State for SpectatorList {
                 .read_schema()?;
 
             let observer_target_handle = {
-                let observer_services_ptr = observer_pawn.m_pObserverServices();
-                let observer_services = observer_services_ptr?
+                let observer_services = observer_pawn
+                    .m_pObserverServices()?
                     .try_reference_schema()
                     .with_context(|| obfstr!("failed to read observer services").to_string())?;
 
@@ -65,32 +62,8 @@ impl State for SpectatorList {
                 }
             };
 
-            let current_observer_target = entities.get_by_handle(&observer_target_handle)?;
-            let observer_target_pawn = if let Some(identity) = &current_observer_target {
-                identity
-                    .entity()?
-                    .cast::<C_CSPlayerPawnBase>()
-                    .try_reference_schema()
-                    .with_context(|| obfstr!("failed to observer target pawn").to_string())?
-            } else {
-                continue;
-            };
-
-            let observer_target_pawn = match observer_target_pawn {
-                Some(pawn) => pawn,
-                None => {
-                    continue;
-                }
-            };
-
-            let target_controller_handle = match observer_target_pawn.m_hController() {
-                Ok(controller) => controller,
-                Err(_e) => {
-                    continue;
-                }
-            };
-
-            if target_controller_handle.get_entity_index() != target_entity_index {
+            let observer_target_index = observer_target_handle.get_entity_index();
+            if observer_target_index != target_entity_index {
                 continue;
             }
 
@@ -125,7 +98,7 @@ impl State for SpectatorList {
 /// Get the controller id which we're currently following
 pub struct LocalCameraControllerTarget {
     pub is_local_entity: bool,
-    pub target_controller_entity_id: Option<u32>,
+    pub target_entity_id: Option<u32>,
 }
 
 impl State for LocalCameraControllerTarget {
@@ -144,7 +117,7 @@ impl State for LocalCameraControllerTarget {
             None => {
                 /* We're currently not connected */
                 return Ok(Self {
-                    target_controller_entity_id: None,
+                    target_entity_id: None,
                     is_local_entity: false,
                 });
             }
@@ -153,13 +126,12 @@ impl State for LocalCameraControllerTarget {
         if player_controller.m_bPawnIsAlive()? {
             /*
              * Our player pawn is alive.
-             * This most certenly means we're currently following our pawn.
+             * This most certainly means we're currently following our pawn.
              */
-            let entity_index = player_controller
-                .m_hOriginalControllerOfCurrentPawn()?
-                .get_entity_index();
+            let local_entity_handle = player_controller.m_hPlayerPawn()?;
+
             Ok(Self {
-                target_controller_entity_id: Some(entity_index),
+                target_entity_id: Some(local_entity_handle.get_entity_index()),
                 is_local_entity: true,
             })
         } else {
@@ -169,7 +141,7 @@ impl State for LocalCameraControllerTarget {
                     None => {
                         /* this is odd... */
                         return Ok(Self {
-                            target_controller_entity_id: None,
+                            target_entity_id: None,
                             is_local_entity: false,
                         });
                     }
@@ -180,26 +152,9 @@ impl State for LocalCameraControllerTarget {
                 .reference_schema()?
                 .m_hObserverTarget()?;
 
-            let local_observed_controller = entities
-                .get_by_handle(&observer_target_handle)?
-                .map(|identity| {
-                    identity
-                        .entity()?
-                        .cast::<C_CSPlayerPawnBase>()
-                        .try_reference_schema()
-                        .with_context(|| {
-                            obfstr!("failed to read local observer target pawn").to_string()
-                        })
-                })
-                .transpose()?
-                .flatten()
-                .map(|player_pawn| player_pawn.m_hController())
-                .transpose()?;
-
             Ok(Self {
                 is_local_entity: false,
-                target_controller_entity_id: local_observed_controller
-                    .map(|identity| identity.get_entity_index()),
+                target_entity_id: Some(observer_target_handle.get_entity_index()),
             })
         }
     }

--- a/cs2/src/state/observer.rs
+++ b/cs2/src/state/observer.rs
@@ -20,7 +20,7 @@ pub struct SpectatorInfo {
 }
 
 pub struct SpectatorList {
-    pub target_entity_index: u32,
+    pub target_entity_handle_index: u32,
     pub spectators: Vec<SpectatorInfo>,
 }
 
@@ -29,7 +29,7 @@ impl State for SpectatorList {
 
     fn create(
         states: &StateRegistry,
-        target_entity_index: Self::Parameter,
+        target_entity_handle_index: Self::Parameter,
     ) -> anyhow::Result<Self> {
         let entities = states.resolve::<EntitySystem>(())?;
         let class_name_cache = states.resolve::<ClassNameCache>(())?;
@@ -62,8 +62,7 @@ impl State for SpectatorList {
                 }
             };
 
-            let observer_target_index = observer_target_handle.get_entity_index();
-            if observer_target_index != target_entity_index {
+            if observer_target_handle.value != target_entity_handle_index {
                 continue;
             }
 
@@ -86,7 +85,7 @@ impl State for SpectatorList {
 
         Ok(Self {
             spectators,
-            target_entity_index,
+            target_entity_handle_index,
         })
     }
 
@@ -98,7 +97,7 @@ impl State for SpectatorList {
 /// Get the controller id which we're currently following
 pub struct LocalCameraControllerTarget {
     pub is_local_entity: bool,
-    pub target_entity_id: Option<u32>,
+    pub target_entity_handle_index: Option<u32>,
 }
 
 impl State for LocalCameraControllerTarget {
@@ -117,7 +116,7 @@ impl State for LocalCameraControllerTarget {
             None => {
                 /* We're currently not connected */
                 return Ok(Self {
-                    target_entity_id: None,
+                    target_entity_handle_index: None,
                     is_local_entity: false,
                 });
             }
@@ -139,14 +138,14 @@ impl State for LocalCameraControllerTarget {
                     None => {
                         /* this is odd... */
                         return Ok(Self {
-                            target_entity_id: None,
+                            target_entity_handle_index: None,
                             is_local_entity: false,
                         });
                     }
                 };
 
             Ok(Self {
-                target_entity_id: Some(local_entity_controller.m_hPlayerPawn()?.value),
+                target_entity_handle_index: Some(local_entity_controller.m_hPlayerPawn()?.value),
                 is_local_entity: true,
             })
         } else {
@@ -156,7 +155,7 @@ impl State for LocalCameraControllerTarget {
                     None => {
                         /* this is odd... */
                         return Ok(Self {
-                            target_entity_id: None,
+                            target_entity_handle_index: None,
                             is_local_entity: false,
                         });
                     }
@@ -169,15 +168,15 @@ impl State for LocalCameraControllerTarget {
 
             if !observer_target_handle.is_valid() {
                 return Ok(Self {
-                    target_entity_id: None,
+                    target_entity_handle_index: None,
                     is_local_entity: false,
                 });
             }
-            let target_entity_id = observer_target_handle.value;
+            let target_entity_handle_index = observer_target_handle.value;
 
             Ok(Self {
                 is_local_entity: false,
-                target_entity_id: Some(target_entity_id),
+                target_entity_handle_index: Some(target_entity_handle_index),
             })
         }
     }


### PR DESCRIPTION
The changes primarily focus on refactoring and fixing bugs in the handling of ESP and spectators list. 

In the `observer.rs` file, in the `create` function, the 'target_controller_entity_id', which represented 'EntityHandle<CCSPlayerController>.get_entity_index()', was replaced by 'target_entity_handle_index', which represents `EntityHandle<C_BaseEntity>.value`. This adjustment was made because `observer_target` can now also be `C_PlantedC4`. 
The check for matching target entities has been updated to use `observer_target_handle.value`. I am not sure that this is optimal, as I don't even know what the 'serial_number` represents, so I will be happy to hear your opinion.

In the `player.rs` file, the local player controller is now fetched directly using the `get_local_player_controller` function and is used to update `local_team_id`. 
The code for fetching the local player's pawn position has been removed. The distance calculation for each player now uses `view_world_position` instead of `local_pos`.

In the `world.rs` file, a new function `get_view_world_position` has been added to the `ViewController` structure. This function calculates the world position based on the view matrix.