### PR TITLE
Updated offsets and signature for new update, crosshair entity id is now used from PlayerPawn

### DIFF
--- a/controller/src/view/crosshair.rs
+++ b/controller/src/view/crosshair.rs
@@ -3,8 +3,6 @@ use std::time::Instant;
 use anyhow::Context;
 use cs2::{
     CEntityIdentityEx,
-    CS2HandleState,
-    CS2Offsets,
     ClassNameCache,
     EntitySystem,
 };
@@ -85,8 +83,6 @@ impl LocalCrosshair {
     }
 
     fn read_crosshair_entity(&self, states: &StateRegistry) -> anyhow::Result<Option<u32>> {
-        let offsets = states.resolve::<CS2Offsets>(())?;
-        let cs2 = states.resolve::<CS2HandleState>(())?;
         let entities = states.resolve::<EntitySystem>(())?;
 
         let local_player_controller = entities
@@ -104,8 +100,8 @@ impl LocalCrosshair {
                 None => return Ok(None),
             };
 
-        let entity_id = cs2
-            .reference_schema::<u32>(&[local_pawn_ptr.address()? + offsets.offset_crosshair_id])?;
+        //let entity_id = 0xFFFFFFFF;
+        let entity_id = local_pawn_ptr.reference_schema()?.m_iIDEntIndex()?;
         if entity_id != 0xFFFFFFFF {
             Ok(Some(entity_id))
         } else {

--- a/cs2/src/map.rs
+++ b/cs2/src/map.rs
@@ -17,8 +17,8 @@ use crate::{
 
 define_schema! {
     pub struct CNetworkGameClient[0x290] {
-        pub map_path: PtrCStr = 0x240,
-        pub map_name: PtrCStr = 0x248,
+        pub map_path: PtrCStr = 0x202,
+        pub map_name: PtrCStr = 0x210,
     }
 }
 

--- a/cs2/src/offsets.rs
+++ b/cs2/src/offsets.rs
@@ -29,9 +29,6 @@ pub struct CS2Offsets {
     /// Address for the global world to screen view matrix
     pub view_matrix: u64,
 
-    /// Offset for the crosshair entity id in C_CSPlayerPawn
-    pub offset_crosshair_id: u64,
-
     /// Offset of the CNetworkGameClient
     pub network_game_client_instance: u64,
 }
@@ -51,8 +48,6 @@ impl State for CS2Offsets {
                 .with_context(|| obfstr!("global entity list").to_string())?,
             view_matrix: Self::find_view_matrix(cs2)
                 .with_context(|| obfstr!("view matrix").to_string())?,
-            offset_crosshair_id: Self::find_offset_crosshair_id(cs2)
-                .with_context(|| obfstr!("crosshair id").to_string())?,
             network_game_client_instance: Self::find_network_game_client_instance(cs2)
                 .with_context(|| obfstr!("network game client instance").to_string())?,
         })
@@ -69,7 +64,7 @@ impl CS2Offsets {
             Module::Client,
             &Signature::relative_address(
                 obfstr!("client globals"),
-                obfstr!("48 89 15 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 85 D2"),
+                obfstr!("48 8B 05 ? ? ? ? 8B 48 04 FF C1"),
                 0x03,
                 0x07,
             ),
@@ -110,17 +105,6 @@ impl CS2Offsets {
                 obfstr!("48 8D 0D ? ? ? ? 48 C1 E0 06"),
                 0x03,
                 0x07,
-            ),
-        )
-    }
-
-    fn find_offset_crosshair_id(cs2: &CS2Handle) -> anyhow::Result<u64> {
-        cs2.resolve_signature(
-            Module::Client,
-            &Signature::offset(
-                obfstr!("C_CSPlayerPawn crosshair id"),
-                obfstr!("41 89 86 ? ? ? ? 41 89 86"),
-                0x03,
             ),
         )
     }


### PR DESCRIPTION
Changes: 
1. Updated globals signature
2. Removed finding of local crosshair id offset by signature, m_iIDEntIndex from C_CSPlayerPawn is now used
3. Updated generated schema
4. Updated map offset

Possible issue: Field types for UtlVector and others are now null in generated schema. It doesn't seem to cause any issues.

Resolves https://github.com/Valthrun/Valthrun/issues/161