### PR TITLE
Feat 163 web radar plant details

### DIFF
--- a/radar/client/src/generator.rs
+++ b/radar/client/src/generator.rs
@@ -45,6 +45,8 @@ impl BombData for C_C4 {
                 position,
                 state: C4State::Dropped,
                 bomb_site: None,
+                time_detonation: None,
+                defuser: None,
             });
         }
 
@@ -52,6 +54,8 @@ impl BombData for C_C4 {
             position,
             state: C4State::Carried,
             bomb_site: None,
+            time_detonation: None,
+            defuser: None,
         })
     }
 }
@@ -69,6 +73,8 @@ impl BombData for C_PlantedC4 {
                 position,
                 state: C4State::Defused,
                 bomb_site,
+                time_detonation: None,
+                defuser: None,
             });
         }
 
@@ -78,6 +84,8 @@ impl BombData for C_PlantedC4 {
                 position,
                 bomb_site,
                 state: C4State::Detonated,
+                time_detonation: None,
+                defuser: None,
             });
         }
 
@@ -115,11 +123,10 @@ impl BombData for C_PlantedC4 {
 
         Ok(RadarBombInfo {
             position,
-            state: C4State::Active {
-                time_detonation: time_blow - globals.time_2()?,
-                defuse: defusing,
-            },
+            state: C4State::Active,
             bomb_site,
+            time_detonation: Some(time_blow - globals.time_2()?),
+            defuser: defusing,
         })
     }
 }

--- a/radar/client/src/generator.rs
+++ b/radar/client/src/generator.rs
@@ -44,18 +44,12 @@ impl BombData for C_C4 {
             return Ok(RadarBombInfo {
                 position,
                 state: C4State::Dropped,
-                bomb_site: None,
-                time_detonation: None,
-                defuser: None,
             });
         }
 
         Ok(RadarBombInfo {
             position,
             state: C4State::Carried,
-            bomb_site: None,
-            time_detonation: None,
-            defuser: None,
         })
     }
 }
@@ -66,15 +60,14 @@ impl BombData for C_PlantedC4 {
         let entities = generator.states.resolve::<EntitySystem>(())?;
 
         let position = self.m_pGameSceneNode()?.read_schema()?.m_vecAbsOrigin()?;
-        let bomb_site = Some(self.m_nBombSite()? as u8);
+        let bomb_site = self.m_nBombSite()? as u8;
 
         if self.m_bBombDefused()? {
             return Ok(RadarBombInfo {
                 position,
-                state: C4State::Defused,
-                bomb_site,
-                time_detonation: None,
-                defuser: None,
+                state: C4State::Defused{
+                    bomb_site,
+                },
             });
         }
 
@@ -82,10 +75,9 @@ impl BombData for C_PlantedC4 {
         if time_blow <= globals.time_2()? {
             return Ok(RadarBombInfo {
                 position,
-                bomb_site,
-                state: C4State::Detonated,
-                time_detonation: None,
-                defuser: None,
+                state: C4State::Detonated{
+                    bomb_site,
+                },
             });
         }
 
@@ -123,10 +115,11 @@ impl BombData for C_PlantedC4 {
 
         Ok(RadarBombInfo {
             position,
-            state: C4State::Active,
-            bomb_site,
-            time_detonation: Some(time_blow - globals.time_2()?),
-            defuser: defusing,
+            state: C4State::Active{
+                bomb_site,
+                time_detonation: time_blow - globals.time_2()?,
+                defuser: defusing,
+            },
         })
     }
 }

--- a/radar/shared/src/types.rs
+++ b/radar/shared/src/types.rs
@@ -21,7 +21,7 @@ pub struct BombDefuser {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase", tag = "variant", content = "data")]
+#[serde(rename_all = "camelCase", tag = "variant")]
 pub enum C4State {
     /// Bomb is dropped
     Dropped,

--- a/radar/shared/src/types.rs
+++ b/radar/shared/src/types.rs
@@ -21,7 +21,7 @@ pub struct BombDefuser {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", tag = "variant", content = "data")]
 pub enum C4State {
     /// Bomb is dropped
     Dropped,
@@ -30,13 +30,34 @@ pub enum C4State {
     Carried,
 
     /// Bomb is currently actively ticking
-    Active,
+    Active{
+        /// Planted bomb site
+        /// 0 = A
+        /// 1 = B
+        bomb_site: u8,
+
+        /// Time remaining (in seconds) until detonation
+        time_detonation: f32,
+
+        /// Current bomb defuser
+        defuser: Option<BombDefuser>,
+    },
 
     /// Bomb has detonated
-    Detonated,
+    Detonated{
+        /// Planted bomb site
+        /// 0 = A
+        /// 1 = B
+        bomb_site: u8,
+    },
 
     /// Bomb has been defused
-    Defused,
+    Defused{
+        /// Planted bomb site
+        /// 0 = A
+        /// 1 = B
+        bomb_site: u8,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -68,15 +89,4 @@ pub struct RadarPlayerInfo {
 pub struct RadarBombInfo {
     pub position: [f32; 3],
     pub state: C4State,
-
-    /// Planted bomb site
-    /// 0 = A
-    /// 1 = B
-    pub bomb_site: Option<u8>,
-
-    /// Time remaining (in seconds) until detonation
-    pub time_detonation: Option<f32>,
-
-    /// Current bomb defuser
-    pub defuser: Option<BombDefuser>,
 }

--- a/radar/shared/src/types.rs
+++ b/radar/shared/src/types.rs
@@ -30,13 +30,7 @@ pub enum C4State {
     Carried,
 
     /// Bomb is currently actively ticking
-    Active {
-        /// Time remaining (in seconds) until detonation
-        time_detonation: f32,
-
-        /// Current bomb defuser
-        defuse: Option<BombDefuser>,
-    },
+    Active,
 
     /// Bomb has detonated
     Detonated,
@@ -79,4 +73,10 @@ pub struct RadarBombInfo {
     /// 0 = A
     /// 1 = B
     pub bomb_site: Option<u8>,
+
+    /// Time remaining (in seconds) until detonation
+    pub time_detonation: Option<f32>,
+
+    /// Current bomb defuser
+    pub defuser: Option<BombDefuser>,
 }

--- a/radar/web/src/backend/connection.ts
+++ b/radar/web/src/backend/connection.ts
@@ -184,26 +184,20 @@ export type C4State =
     | {variant: 'dropped'}
     | {
         variant:'active',
-        data:{
-            bomb_site: number,
-            time_detonation: number,
-            defuser: BombDefuser | null,
-        },
+        bomb_site: number,
+        time_detonation: number,
+        defuser: BombDefuser | null,
     }
     | {
         variant:'detonated',
-        data: {
-            bomb_site: number,
-        },
+        bomb_site: number,
     }
     | {
         variant:'defused',
-        data: {
-            bomb_site: number,
-        },
+        bomb_site: number,
     };
 
 export type BombDefuser = {
-    timeRemaining: number;
-    playerName: string
+    timeRemaining: number,
+    playerName: string,
 };

--- a/radar/web/src/backend/connection.ts
+++ b/radar/web/src/backend/connection.ts
@@ -178,18 +178,16 @@ export type RadarBombInfo = {
     position: [number, number, number],
     state: C4State,
     bombSite: number | null,
+    timeDetonation: number | null,
+    defuser: BombDefuser | null,
 };
 
 export type C4State =
-    | { variant: 'Carried' }
-    | { variant: 'Dropped'}
-    | {
-    variant: 'Active';
-    timeDetonation: number;
-    defuse: BombDefuser | null;
-}
-    | { variant: 'Detonated' }
-    | { variant: 'Defused' };
+    | 'carried'
+    | 'dropped'
+    | 'active'
+    | 'detonated'
+    | 'defused';
 
 export type BombDefuser = {
     timeRemaining: number;

--- a/radar/web/src/backend/connection.ts
+++ b/radar/web/src/backend/connection.ts
@@ -177,17 +177,31 @@ export type RadarPlayerInfo = {
 export type RadarBombInfo = {
     position: [number, number, number],
     state: C4State,
-    bombSite: number | null,
-    timeDetonation: number | null,
-    defuser: BombDefuser | null,
 };
 
 export type C4State =
-    | 'carried'
-    | 'dropped'
-    | 'active'
-    | 'detonated'
-    | 'defused';
+    | {variant: 'carried'}
+    | {variant: 'dropped'}
+    | {
+        variant:'active',
+        data:{
+            bomb_site: number,
+            time_detonation: number,
+            defuser: BombDefuser | null,
+        },
+    }
+    | {
+        variant:'detonated',
+        data: {
+            bomb_site: number,
+        },
+    }
+    | {
+        variant:'defused',
+        data: {
+            bomb_site: number,
+        },
+    };
 
 export type BombDefuser = {
     timeRemaining: number;

--- a/radar/web/src/state/radar-settings.ts
+++ b/radar/web/src/state/radar-settings.ts
@@ -6,12 +6,14 @@ export type State = {
     dialogOpen: boolean,
 
     iconSize: number,
+    displayBombDetails: boolean,
 };
 const slice = createSlice({
     name: "radar-settings",
     initialState: (): State => ({
         dialogOpen: false,
-        iconSize: 3.0
+        iconSize: 3.0,
+        displayBombDetails: true,
     }),
     reducers: {
         updateRadarSettings: (state, action: PayloadAction<Partial<State>>) => {

--- a/radar/web/src/ui/pages/session/[id]/modal-settings.tsx
+++ b/radar/web/src/ui/pages/session/[id]/modal-settings.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Modal, Slider, Typography } from "@mui/material";
+import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Modal, Slider, Typography, Switch } from "@mui/material";
 import { useAppDispatch, useAppSelector } from "../../../../state"
 import { updateRadarSettings } from "../../../../state/radar-settings";
 import React from "react";
@@ -18,6 +18,7 @@ export default React.memo(() => {
             </DialogTitle>
             <DialogContent sx={{ width: "15em", height: "10em", overflow: "visible" }}>
                 <SettingIconSize />
+                <SettingBombDisplay />
             </DialogContent>
             <DialogActions>
                 <Button onClick={() => dispatch(updateRadarSettings({ dialogOpen: false }))}>Close</Button>
@@ -42,6 +43,21 @@ const SettingIconSize = React.memo(() => {
                 onChange={(_event, value) => dispatch(updateRadarSettings({ iconSize: value }))}
 
                 valueLabelDisplay={"auto"}
+            />
+        </Box>
+    );
+})
+
+const SettingBombDisplay = React.memo(() => {
+    const value = useAppSelector(state => state.radarSettings.displayBombDetails);
+    const dispatch = useAppDispatch();
+
+    return (
+        <Box>
+            <Typography variant={"subtitle1"}>Display Bomb Details</Typography>
+            <Switch
+                checked={value}
+                onChange={(_event, value) => dispatch(updateRadarSettings({ displayBombDetails: value }))}
             />
         </Box>
     );

--- a/radar/web/src/ui/pages/session/[id]/radar.tsx
+++ b/radar/web/src/ui/pages/session/[id]/radar.tsx
@@ -301,9 +301,8 @@ const BombDetails = React.memo(() => {
 
         style={{
             "flex-shrink": 2,
-            "word-wrap": "break-word",
             "white-space": "pre-wrap",
-            "word-break": "break-word",
+            "overflow-wrap": "break-word",
         } as any}
         >
             <Typography variant={"h6"} sx={{ alignSelf: "center", color: "grey.500" }}>Bomb Info</Typography>
@@ -328,7 +327,7 @@ const PlantDetails = React.memo(() => {
 
     return (
         <Box>
-            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Bomb Site: {bomb.state.data.bomb_site == 0 ? "A" : "B"}</Typography>
+            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Bomb Site: {bomb.state.bomb_site == 0 ? "A" : "B"}</Typography>
             {bomb.state.variant == 'active' ? <DefuseDetails /> : null}
         </Box>
     )
@@ -348,8 +347,8 @@ const DefuseDetails = React.memo(() => {
     }
 
     let defuseColor = "grey.600";
-    if(bomb.state.data.defuser != null){
-        if (bomb.state.data.time_detonation < bomb.state.data.defuser.timeRemaining){
+    if(bomb.state.defuser != null){
+        if (bomb.state.time_detonation < bomb.state.defuser.timeRemaining){
             defuseColor = red['600'];
         } else{
             defuseColor = green['600'];
@@ -360,9 +359,9 @@ const DefuseDetails = React.memo(() => {
 
     return (
         <Box>
-            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Bomb explode in: {bomb.state.data.time_detonation}</Typography>
-            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Defusing by: {bomb.state.data.defuser != null ? bomb.state.data.defuser.playerName : 'None'}</Typography>
-            <Typography variant={"body1"} sx={{ alignSelf: "left", color: defuseColor }}>Defuse in: {bomb.state.data.defuser != null ? bomb.state.data.defuser.timeRemaining : 'None' }</Typography>
+            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Bomb explode in: {bomb.state.time_detonation}</Typography>
+            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Defusing by: {bomb.state.defuser != null ? bomb.state.defuser.playerName : 'None'}</Typography>
+            <Typography variant={"body1"} sx={{ alignSelf: "left", color: defuseColor }}>Defuse in: {bomb.state.defuser != null ? bomb.state.defuser.timeRemaining : 'None' }</Typography>
         </Box>
     )
 });

--- a/radar/web/src/ui/pages/session/[id]/radar.tsx
+++ b/radar/web/src/ui/pages/session/[id]/radar.tsx
@@ -54,14 +54,25 @@ export const RadarRenderer = React.memo(() => {
                 p: 3,
             }}>
                 <Typography variant={"h5"}>{mapInfo?.displayName ?? worldName}</Typography>
-                <SqareContainer>
-                    <MapRenderer />
-                    {!mapInfo && (
-                        <Box sx={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0, display: "flex", flexDirection: "column", justifyContent: "center" }}>
-                            <Typography variant={"h5"} sx={{ alignSelf: "center", color: "grey.500" }}>loading map info</Typography>
-                        </Box>
-                    )}
-                </SqareContainer>
+                <Box sx={{
+                    height: "100%",
+                    width: "100%",
+
+                    display: "flex",
+                    flexDirection: "row",
+
+                    p: 3,
+                }}>
+                    <PlantDetails />
+                    <SqareContainer>
+                        <MapRenderer />
+                        {!mapInfo && (
+                            <Box sx={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0, display: "flex", flexDirection: "column", justifyContent: "center" }}>
+                                <Typography variant={"h5"} sx={{ alignSelf: "center", color: "grey.500" }}>loading map info</Typography>
+                            </Box>
+                        )}
+                    </SqareContainer>
+                </Box>
             </Box>
         </ContextMap.Provider>
     );
@@ -264,5 +275,56 @@ const MapBombPing = React.memo((props: {
                 "--pos-y": `${bombY * 100 / mapSize - iconSize / 2 + (floor?.offset.y ?? 0)}%`,
             } as any}
         />
+    )
+});
+
+const PlantDetails = React.memo(() => {
+    const { players, bomb } = React.useContext(ContextRadarState);
+    const map = React.useContext(ContextMap);
+
+    if (!bomb) {
+        /* we need the map and bomb info */
+        return null;
+    }
+
+    return (
+        <Box sx={{
+            width: `10%`
+        }}
+
+        style={{
+            "flex-shrink": 2,
+            "word-wrap": "break-word",
+            "white-space": "pre-wrap",
+            "word-break": "break-word",
+        } as any}
+        >
+            <Typography variant={"h6"} sx={{ alignSelf: "center", color: "grey.500" }}>Bomb Info</Typography>
+            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Bomb Status: {bomb.state}</Typography>
+            {bomb.state == "active" ? <DefuseDetails /> : null}
+        </Box>
+    )
+});
+
+const DefuseDetails = React.memo(() => {
+    const { players, bomb } = React.useContext(ContextRadarState);
+    const map = React.useContext(ContextMap);
+
+    if (!bomb) {
+        /* we need the map and bomb info */
+        return null;
+    }
+
+    if (bomb.state != 'active' ){
+        return null;
+    }
+
+    return (
+        <Box>
+            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Bomb Site: {bomb.bombSite == 0 ? "A" : "B"}</Typography>
+            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Bomb explode in: {bomb.timeDetonation}</Typography>
+            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Defusing by: {bomb.defuser.playerName != null ? bomb.defuser.playerName : 'None'}</Typography>
+            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Defuse in: {bomb.defuser.timeRemaining  != null ? bomb.defuser.timeRemaining : 'None' }</Typography>
+        </Box>
     )
 });

--- a/radar/web/src/ui/pages/session/[id]/radar.tsx
+++ b/radar/web/src/ui/pages/session/[id]/radar.tsx
@@ -8,6 +8,7 @@ import ImageYellowCross from "../../../../assets/yellow_cross.png";
 import ImageYellowDot from "../../../../assets/yellow_dot.png";
 import ImageBomb from "../../../../assets/bomb.png";
 import { useAppSelector } from "../../../../state";
+import { green, red } from '@mui/material/colors';
 
 export const ContextRadarState = React.createContext<RadarState>({
     players: [],
@@ -306,8 +307,8 @@ const BombDetails = React.memo(() => {
         } as any}
         >
             <Typography variant={"h6"} sx={{ alignSelf: "center", color: "grey.500" }}>Bomb Info</Typography>
-            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Bomb Status: {bomb.state}</Typography>
-            {bomb.state == "active" ? <PlantDetails /> : null}
+            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Bomb Status: {bomb.state.variant}</Typography>
+            {bomb.state.variant == "active" || bomb.state.variant == "detonated" || bomb.state.variant == "defused" ? <PlantDetails /> : null}
         </Box>
     )
 });
@@ -321,15 +322,14 @@ const PlantDetails = React.memo(() => {
         return null;
     }
 
-    if (bomb.state != 'active' ){
+    if (bomb.state.variant == "dropped" || bomb.state.variant == "carried" ){
         return null;
     }
 
     return (
         <Box>
-            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Bomb Site: {bomb.bombSite == 0 ? "A" : "B"}</Typography>
-            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Bomb explode in: {bomb.timeDetonation}</Typography>
-            {bomb.defuser != null ? <DefuseDetails /> : null}
+            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Bomb Site: {bomb.state.data.bomb_site == 0 ? "A" : "B"}</Typography>
+            {bomb.state.variant == 'active' ? <DefuseDetails /> : null}
         </Box>
     )
 });
@@ -343,14 +343,26 @@ const DefuseDetails = React.memo(() => {
         return null;
     }
 
-    if (bomb.defuser == null ){
+    if (bomb.state.variant != "active" ){
         return null;
+    }
+
+    let defuseColor = "grey.600";
+    if(bomb.state.data.defuser != null){
+        if (bomb.state.data.time_detonation < bomb.state.data.defuser.timeRemaining){
+            defuseColor = red['600'];
+        } else{
+            defuseColor = green['600'];
+        }
+    }else{
+        defuseColor = "grey.600";
     }
 
     return (
         <Box>
-            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Defusing by: {bomb.defuser.playerName != null ? bomb.defuser.playerName : 'None'}</Typography>
-            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Defuse in: {bomb.defuser.timeRemaining  != null ? bomb.defuser.timeRemaining : 'None' }</Typography>
+            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Bomb explode in: {bomb.state.data.time_detonation}</Typography>
+            <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Defusing by: {bomb.state.data.defuser != null ? bomb.state.data.defuser.playerName : 'None'}</Typography>
+            <Typography variant={"body1"} sx={{ alignSelf: "left", color: defuseColor }}>Defuse in: {bomb.state.data.defuser != null ? bomb.state.data.defuser.timeRemaining : 'None' }</Typography>
         </Box>
     )
 });

--- a/radar/web/src/ui/pages/session/[id]/radar.tsx
+++ b/radar/web/src/ui/pages/session/[id]/radar.tsx
@@ -343,7 +343,7 @@ const DefuseDetails = React.memo(() => {
         return null;
     }
 
-    if (bomb.defuser != null ){
+    if (bomb.defuser == null ){
         return null;
     }
 

--- a/radar/web/src/ui/pages/session/[id]/radar.tsx
+++ b/radar/web/src/ui/pages/session/[id]/radar.tsx
@@ -63,7 +63,7 @@ export const RadarRenderer = React.memo(() => {
 
                     p: 3,
                 }}>
-                    <PlantDetails />
+                    <BombDetails />
                     <SqareContainer>
                         <MapRenderer />
                         {!mapInfo && (
@@ -278,7 +278,7 @@ const MapBombPing = React.memo((props: {
     )
 });
 
-const PlantDetails = React.memo(() => {
+const BombDetails = React.memo(() => {
     const { players, bomb } = React.useContext(ContextRadarState);
     const map = React.useContext(ContextMap);
 
@@ -301,12 +301,12 @@ const PlantDetails = React.memo(() => {
         >
             <Typography variant={"h6"} sx={{ alignSelf: "center", color: "grey.500" }}>Bomb Info</Typography>
             <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Bomb Status: {bomb.state}</Typography>
-            {bomb.state == "active" ? <DefuseDetails /> : null}
+            {bomb.state == "active" ? <PlantDetails /> : null}
         </Box>
     )
 });
 
-const DefuseDetails = React.memo(() => {
+const PlantDetails = React.memo(() => {
     const { players, bomb } = React.useContext(ContextRadarState);
     const map = React.useContext(ContextMap);
 
@@ -323,6 +323,26 @@ const DefuseDetails = React.memo(() => {
         <Box>
             <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Bomb Site: {bomb.bombSite == 0 ? "A" : "B"}</Typography>
             <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Bomb explode in: {bomb.timeDetonation}</Typography>
+            {bomb.defuser != null ? <DefuseDetails /> : null}
+        </Box>
+    )
+});
+
+const DefuseDetails = React.memo(() => {
+    const { players, bomb } = React.useContext(ContextRadarState);
+    const map = React.useContext(ContextMap);
+
+    if (!bomb) {
+        /* we need the map and bomb info */
+        return null;
+    }
+
+    if (bomb.defuser != null ){
+        return null;
+    }
+
+    return (
+        <Box>
             <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Defusing by: {bomb.defuser.playerName != null ? bomb.defuser.playerName : 'None'}</Typography>
             <Typography variant={"body1"} sx={{ alignSelf: "left", color: "grey.600" }}>Defuse in: {bomb.defuser.timeRemaining  != null ? bomb.defuser.timeRemaining : 'None' }</Typography>
         </Box>

--- a/radar/web/src/ui/pages/session/[id]/radar.tsx
+++ b/radar/web/src/ui/pages/session/[id]/radar.tsx
@@ -281,9 +281,15 @@ const MapBombPing = React.memo((props: {
 const BombDetails = React.memo(() => {
     const { players, bomb } = React.useContext(ContextRadarState);
     const map = React.useContext(ContextMap);
+    const displayBombDetails = useAppSelector(state => state.radarSettings.displayBombDetails);
 
     if (!bomb) {
         /* we need the map and bomb info */
+        return null;
+    }
+
+    if(!displayBombDetails){
+        /* radar setting if false */
         return null;
     }
 


### PR DESCRIPTION
Hi,
I would like to contribute to this awesome repository. I am not so smart guy, so this is just some enhancement over previous work.

This feature introduces:
- display in UI details about plant.
- adjust RadarBombInfo type on client to be better usable in front UI.

Note:
Many thanks to this PR: https://github.com/Valthrun/Valthrun/pull/129.
I am not a front developer or React guy or Rust guy. Ugly, but works.

Comparison for type adjustment:

Carried scenario:
Before:
```json
{
   "position":[
      -980,
      -754,
      120.18125
   ],
   "state":"carried",
   "bombSite":null
}
```
After:
```json
{
   "position":[
      -1181,
      -754,
      120.18125
   ],
   "state":"carried",
   "bombSite":null,
   "timeDetonation":null,
   "defuser":null
}
```

Defuser scenario:
Before:
```json
{
   "position":[
      -1696.9688,
      2529.375,
      7.46875
   ],
   "state":{
      "active":{
         "time_detonation":23.19043,
         "defuse":{
            "timeRemaining":2.7998047,
            "playerName":"Waldo"
         }
      }
   },
   "bombSite":1
}
```
After:
```json
{
   "position":[
      -1519.8125,
      2509,
      0.71875
   ],
   "state":"active",
   "bombSite":1,
   "timeDetonation":18.333008,
   "defuser":{
      "timeRemaining":7.301758,
      "playerName":"Maru"
   }
}
```

Screenshots:
![image](https://github.com/user-attachments/assets/bfdcf6a7-3182-491a-8d29-f065875516a0)

![image](https://github.com/user-attachments/assets/9be8a81c-3add-4bd1-8147-cd1752ce0c2c)
