### PR TITLE
Needed Improvments: UI, Coloring

### DIFF
--- a/controller/src/settings/esp.rs
+++ b/controller/src/settings/esp.rs
@@ -102,11 +102,12 @@ impl EspColor {
         }
     }
 
-    fn interpolate_color(start: [f32; 3], end: [f32; 3], t: f32) -> [f32; 3] {
+    fn interpolate_color(start: [f32; 4], end: [f32; 4], t: f32) -> [f32; 4] {
         [
             start[0] + (end[0] - start[0]) * t,
             start[1] + (end[1] - start[1]) * t,
             start[2] + (end[2] - start[2]) * t,
+            start[3] + (end[3] - start[3]) * t,
         ]
     }
 

--- a/controller/src/settings/ui.rs
+++ b/controller/src/settings/ui.rs
@@ -1015,6 +1015,7 @@ impl SettingsUI {
         {
             match color {
                 EspColor::HealthBasedRainbow { alpha } => {
+                    ui.text("Alpha:");
                     ui.same_line();
                     ui.set_next_item_width(100.0);
                     ui.slider_config(
@@ -1095,6 +1096,7 @@ impl SettingsUI {
                         *min = Color::from_f32(min_value);
                     }
 
+                    ui.text("Alpha:");
                     ui.same_line();
                     ui.set_next_item_width(100.0);
                     ui.slider_config(

--- a/controller/src/settings/ui.rs
+++ b/controller/src/settings/ui.rs
@@ -998,14 +998,12 @@ impl SettingsUI {
                         max: Color::from_f32([0.0, 1.0, 0.0, 1.0]),
                         mid: Color::from_f32([1.0, 1.0, 0.0, 1.0]),
                         min: Color::from_f32([1.0, 0.0, 0.0, 1.0]),
-                        alpha: 1.0,
                     },
                     EspColorType::HealthBasedRainbow => EspColor::HealthBasedRainbow { alpha: 1.0 },
                     EspColorType::DistanceBased => EspColor::DistanceBased {
                         near: Color::from_f32([1.0, 0.0, 0.0, 1.0]),
                         mid: Color::from_f32([1.0, 1.0, 0.0, 1.0]),
                         far: Color::from_f32([0.0, 1.0, 0.0, 1.0]),
-                        alpha: 1.0,
                     },
                 }
             }
@@ -1042,19 +1040,14 @@ impl SettingsUI {
                         *value = Color::from_f32(color_value);
                     }
                 }
-                EspColor::HealthBased {
-                    max,
-                    mid,
-                    min,
-                    alpha,
-                } => {
+                EspColor::HealthBased { max, mid, min } => {
                     let mut max_value = max.as_f32();
                     if {
                         ui.color_edit4_config(
                             &format!("##{}_health_max", ui.table_row_index()),
                             &mut max_value,
                         )
-                        .alpha_bar(false)
+                        .alpha_bar(true)
                         .inputs(false)
                         .label(false)
                         .build()
@@ -1071,7 +1064,7 @@ impl SettingsUI {
                             &format!("##{}_health_mid", ui.table_row_index()),
                             &mut mid_value,
                         )
-                        .alpha_bar(false)
+                        .alpha_bar(true)
                         .inputs(false)
                         .label(false)
                         .build()
@@ -1088,38 +1081,22 @@ impl SettingsUI {
                             &format!("##{}_health_min", ui.table_row_index()),
                             &mut min_value,
                         )
-                        .alpha_bar(false)
+                        .alpha_bar(true)
                         .inputs(false)
                         .label(false)
                         .build()
                     } {
                         *min = Color::from_f32(min_value);
                     }
-
-                    ui.text("Alpha:");
-                    ui.same_line();
-                    ui.set_next_item_width(100.0);
-                    ui.slider_config(
-                        &format!("##{}_health_alpha", ui.table_row_index()),
-                        0.1,
-                        1.0,
-                    )
-                    .display_format("%.2f")
-                    .build(alpha);
                 }
-                EspColor::DistanceBased {
-                    near,
-                    mid,
-                    far,
-                    alpha,
-                } => {
+                EspColor::DistanceBased { near, mid, far } => {
                     let mut near_color = near.as_f32();
                     if ui
                         .color_edit4_config(
                             &format!("##{}_near", ui.table_row_index()),
                             &mut near_color,
                         )
-                        .alpha_bar(false)
+                        .alpha_bar(true)
                         .inputs(false)
                         .label(false)
                         .build()
@@ -1136,7 +1113,7 @@ impl SettingsUI {
                             &format!("##{}_mid", ui.table_row_index()),
                             &mut mid_color,
                         )
-                        .alpha_bar(false)
+                        .alpha_bar(true)
                         .inputs(false)
                         .label(false)
                         .build()
@@ -1153,24 +1130,13 @@ impl SettingsUI {
                             &format!("##{}_far", ui.table_row_index()),
                             &mut far_color,
                         )
-                        .alpha_bar(false)
+                        .alpha_bar(true)
                         .inputs(false)
                         .label(false)
                         .build()
                     {
                         *far = Color::from_f32(far_color);
                     }
-
-                    ui.text("Alpha:");
-                    ui.same_line();
-                    ui.set_next_item_width(100.0);
-                    ui.slider_config(
-                        &format!("##{}_distance_alpha", ui.table_row_index()),
-                        0.1,
-                        1.0,
-                    )
-                    .display_format("%.2f")
-                    .build(alpha);
                 }
             }
         }

--- a/controller/src/settings/ui.rs
+++ b/controller/src/settings/ui.rs
@@ -1015,13 +1015,14 @@ impl SettingsUI {
         {
             match color {
                 EspColor::HealthBasedRainbow { alpha } => {
+                    ui.same_line();
                     ui.set_next_item_width(100.0);
                     ui.slider_config(
                         &format!("##{}_rainbow_alpha", ui.table_row_index()),
                         0.1,
                         1.0,
                     )
-                    .display_format("Alpha: %.2f")
+                    .display_format("%.2f")
                     .build(alpha);
                 }
                 EspColor::Static { value } => {
@@ -1094,7 +1095,6 @@ impl SettingsUI {
                         *min = Color::from_f32(min_value);
                     }
 
-                    ui.text("Alpha");
                     ui.same_line();
                     ui.set_next_item_width(100.0);
                     ui.slider_config(
@@ -1102,7 +1102,7 @@ impl SettingsUI {
                         0.1,
                         1.0,
                     )
-                    .display_format("Alpha: %.2f")
+                    .display_format("%.2f")
                     .build(alpha);
                 }
                 EspColor::DistanceBased {
@@ -1159,7 +1159,7 @@ impl SettingsUI {
                         *far = Color::from_f32(far_color);
                     }
 
-                    ui.text("Alpha");
+                    ui.text("Alpha:");
                     ui.same_line();
                     ui.set_next_item_width(100.0);
                     ui.slider_config(


### PR DESCRIPTION
# Improvements

- Increased window width by 50px to resolve symbol rendering issues.
- Enhanced health-based coloring with a third transition color for clearer player visibility.
- Added alpha channel support to all coloring types.
- Made distance-based coloring customizable.

# Showcase

## Health-Based
### Old
Players at half health had a brownish-green color, making them hard to distinguish.
![Old health-based color issue](https://github.com/user-attachments/assets/3323b844-5011-4ad0-9b45-513762bdb7e5)

### New
Improved colors, offering better visibility.
![New health-based color transitions](https://github.com/user-attachments/assets/8030639a-eedb-4c83-b257-a49f0cef0e3e)

## Distance-Based
Demonstration of new alpha support and customizable distance-based coloring.
![Distance-based coloring demo](https://github.com/user-attachments/assets/bd6e469c-516b-4290-b2e3-0c6036ec9ed9)

## UI
### Old
![image](https://github.com/user-attachments/assets/7b071172-b86f-4835-9790-0d2b30662993)

### New
![image](https://github.com/user-attachments/assets/4c51d3cd-37b6-46ab-a22a-ddedd2d3d752)

