### PR TITLE
Fixed schema generation

### DIFF
--- a/cs2/src/schema.rs
+++ b/cs2/src/schema.rs
@@ -569,7 +569,7 @@ pub fn dump_schema(
                 }
             }
 
-            let schema_scope = match schema_scops.entry(scope_name.clone()) {
+            let schema_scope = match schema_scops.entry(class_scope_name.clone()) {
                 Entry::Occupied(entry) => entry.into_mut(),
                 Entry::Vacant(entry) => {
                     let schema_name = entry.key().clone();
@@ -604,7 +604,7 @@ pub fn dump_schema(
                 }
             }
 
-            let schema_scope = match schema_scops.entry(scope_name.clone()) {
+            let schema_scope = match schema_scops.entry(enum_scope_name.clone()) {
                 Entry::Occupied(entry) => entry.into_mut(),
                 Entry::Vacant(entry) => {
                     let schema_name = entry.key().clone();


### PR DESCRIPTION
Resolves #175 

If this is the correct fix, then I don't understand why you added the `class_scope_name`.
Now `class_scope_name` is equal to 'scope_name` and `class_scope_name` isn't used anywhere.
@WolverinDEV 