### PR TITLE
fix(grenade-helper): typo in map name

### DIFF
--- a/controller/src/settings/ui.rs
+++ b/controller/src/settings/ui.rs
@@ -1426,7 +1426,7 @@ impl SettingsUI {
                     display_name: "Thera".to_owned(),
                 },
                 GrenadeSettingsTarget::Map {
-                    map_name: "cs_vertigo".to_owned(),
+                    map_name: "de_vertigo".to_owned(),
                     display_name: "Vertigo".to_owned(),
                 },
             ] {


### PR DESCRIPTION
Fix: #189