### PR TITLE
Fix ESP validation to prevent showing invalid player information

### DIFF
--- a/controller/src/enhancements/player/mod.rs
+++ b/controller/src/enhancements/player/mod.rs
@@ -196,10 +196,6 @@ impl Enhancement for PlayerESP {
                 pawn_model,
             } = entry;
 
-            if pawn_info.player_health <= 0 || pawn_info.player_name.is_none() {
-                continue;
-            }
-
             let distance = (pawn_info.position - view_world_position).norm() * UNITS_TO_METERS;
             let esp_settings = match self.resolve_esp_player_config(&settings, pawn_info) {
                 Some(settings) => settings,

--- a/controller/src/enhancements/player/mod.rs
+++ b/controller/src/enhancements/player/mod.rs
@@ -155,6 +155,10 @@ impl Enhancement for PlayerESP {
                 .states
                 .resolve::<StatePawnInfo>(entity_identity.handle()?)?;
 
+            if pawn_info.player_health <= 0 || pawn_info.player_name.is_none() {
+                continue;
+            }
+
             let pawn_model = ctx
                 .states
                 .resolve::<StatePawnModelInfo>(entity_identity.handle()?)?;
@@ -191,6 +195,10 @@ impl Enhancement for PlayerESP {
                 pawn_info,
                 pawn_model,
             } = entry;
+
+            if pawn_info.player_health <= 0 || pawn_info.player_name.is_none() {
+                continue;
+            }
 
             let distance = (pawn_info.position - view_world_position).norm() * UNITS_TO_METERS;
             let esp_settings = match self.resolve_esp_player_config(&settings, pawn_info) {


### PR DESCRIPTION
This PR improves the ESP system by adding proper validation checks to prevent showing information for invalid players. The changes ensure that ESP elements (name, health, weapon, etc.) are only displayed when the player data is valid and relevant.

Key changes:
- Add validation checks before rendering ESP elements
- Skip rendering for dead or disconnected players

This fixes issues where:
- ESP would show "unknown" for disconnected players
- Information would display for dead players
- Health bars would appear for players with 0 health
- Player names would show as "unknown" instead of being hidden

The changes improve the overall ESP clarity by ensuring only valid and relevant information is displayed to the user.

Preview to showing before resolving the fix:
![image](https://github.com/user-attachments/assets/c4542381-7f09-41d4-b275-e14f02f4d978)
