### PR TITLE
Feature - Add text shadow effects for better readability

### DIFF
--- a/controller/src/constants.rs
+++ b/controller/src/constants.rs
@@ -1,0 +1,2 @@
+/// Offset in pixels for text shadow effects
+pub const TEXT_SHADOW_OFFSET: f32 = 1.0;

--- a/controller/src/constants.rs
+++ b/controller/src/constants.rs
@@ -1,2 +1,0 @@
-/// Offset in pixels for text shadow effects
-pub const TEXT_SHADOW_OFFSET: f32 = 1.0;

--- a/controller/src/enhancements/bomb.rs
+++ b/controller/src/enhancements/bomb.rs
@@ -2,13 +2,12 @@ use cs2::{
     PlantedC4,
     PlantedC4State,
 };
+use imgui::ImColor32;
 use overlay::UnicodeTextRenderer;
+use crate::utils::{TextWithShadowUi, UnicodeTextWithShadowUi};
 
 use super::Enhancement;
-use crate::{
-    settings::AppSettings,
-    constants::TEXT_SHADOW_OFFSET,
-};
+use crate::settings::AppSettings;
 pub struct BombInfoIndicator {}
 
 impl BombInfoIndicator {
@@ -60,64 +59,48 @@ impl Enhancement for BombInfoIndicator {
             + 0_f32.max((ui.io().display_size[1] * PLAYER_AVATAR_SIZE - text_height) / 2.0);
 
         // Bomb site text
-        let text = format!(
+        ui.set_cursor_pos([offset_x, offset_y]);
+        ui.text_with_shadow(&format!(
             "Bomb planted {}",
             if bomb_state.bomb_site == 0 { "A" } else { "B" }
-        );
-        ui.set_cursor_pos([offset_x + TEXT_SHADOW_OFFSET, offset_y + TEXT_SHADOW_OFFSET]);
-        unicode_text.text_colored([0.0, 0.0, 0.0, 0.5], &text);
-        ui.set_cursor_pos([offset_x, offset_y]);
-        unicode_text.text(&text);
+        ));
 
-        let mut current_y = offset_y + ui.text_line_height_with_spacing();
+        let mut offset_y = offset_y + ui.text_line_height_with_spacing();
 
         match &bomb_state.state {
             PlantedC4State::Active { time_detonation } => {
                 // Time text
-                let time_text = format!("Time: {:.3}", time_detonation);
-                ui.set_cursor_pos([offset_x + TEXT_SHADOW_OFFSET, current_y + TEXT_SHADOW_OFFSET]);
-                unicode_text.text_colored([0.0, 0.0, 0.0, 0.5], &time_text);
-                ui.set_cursor_pos([offset_x, current_y]);
-                unicode_text.text(&time_text);
-                
-                current_y += ui.text_line_height_with_spacing();
+                ui.set_cursor_pos([offset_x, offset_y]);
+                ui.text_with_shadow(&format!("Time: {:.3}", time_detonation));
+
+                offset_y += ui.text_line_height_with_spacing();
 
                 if let Some(defuser) = &bomb_state.defuser {
                     let color = if defuser.time_remaining > *time_detonation {
-                        [0.79, 0.11, 0.11, 1.0]
+                        ImColor32::from_rgba(201, 28, 28, 255) // Red
                     } else {
-                        [0.11, 0.79, 0.26, 1.0]
+                        ImColor32::from_rgba(28, 201, 66, 255) // Green
                     };
 
                     let defuse_text = format!(
                         "Defused in {:.3} by {}",
                         defuser.time_remaining, defuser.player_name
                     );
-                    ui.set_cursor_pos([offset_x + TEXT_SHADOW_OFFSET, current_y + TEXT_SHADOW_OFFSET]);
-                    unicode_text.text_colored([0.0, 0.0, 0.0, 0.5], &defuse_text);
-                    ui.set_cursor_pos([offset_x, current_y]);
-                    unicode_text.text_colored(color, &defuse_text);
+
+                    ui.set_cursor_pos([offset_x, offset_y]);
+                    ui.unicode_text_colored_with_shadow(unicode_text, color, &defuse_text);
                 } else {
-                    let not_defusing_text = "Not defusing";
-                    ui.set_cursor_pos([offset_x + TEXT_SHADOW_OFFSET, current_y + TEXT_SHADOW_OFFSET]);
-                    unicode_text.text_colored([0.0, 0.0, 0.0, 0.5], not_defusing_text);
-                    ui.set_cursor_pos([offset_x, current_y]);
-                    unicode_text.text(not_defusing_text);
+                    ui.set_cursor_pos([offset_x, offset_y]);
+                    ui.text_with_shadow("Not defusing");
                 }
             }
             PlantedC4State::Defused => {
-                let text = "Bomb has been defused";
-                ui.set_cursor_pos([offset_x + TEXT_SHADOW_OFFSET, current_y + TEXT_SHADOW_OFFSET]);
-                unicode_text.text_colored([0.0, 0.0, 0.0, 0.5], text);
-                ui.set_cursor_pos([offset_x, current_y]);
-                unicode_text.text(text);
+                ui.set_cursor_pos([offset_x, offset_y]);
+                ui.text_with_shadow("Bomb has been defused");
             }
             PlantedC4State::Detonated => {
-                let text = "Bomb has been detonated";
-                ui.set_cursor_pos([offset_x + TEXT_SHADOW_OFFSET, current_y + TEXT_SHADOW_OFFSET]);
-                unicode_text.text_colored([0.0, 0.0, 0.0, 0.5], text);
-                ui.set_cursor_pos([offset_x, current_y]);
-                unicode_text.text(text);
+                ui.set_cursor_pos([offset_x, offset_y]);
+                ui.text_with_shadow("Bomb has been detonated");
             }
             PlantedC4State::NotPlanted => unreachable!(),
         }

--- a/controller/src/enhancements/bomb.rs
+++ b/controller/src/enhancements/bomb.rs
@@ -7,7 +7,7 @@ use overlay::UnicodeTextRenderer;
 use super::Enhancement;
 use crate::{
     settings::AppSettings,
-    utils::ImguiUiEx,
+    constants::TEXT_SHADOW_OFFSET,
 };
 pub struct BombInfoIndicator {}
 
@@ -59,16 +59,29 @@ impl Enhancement for BombInfoIndicator {
         let offset_y = offset_y
             + 0_f32.max((ui.io().display_size[1] * PLAYER_AVATAR_SIZE - text_height) / 2.0);
 
-        ui.set_cursor_pos([offset_x, offset_y]);
-        ui.text(&format!(
+        // Bomb site text
+        let text = format!(
             "Bomb planted {}",
             if bomb_state.bomb_site == 0 { "A" } else { "B" }
-        ));
+        );
+        ui.set_cursor_pos([offset_x + TEXT_SHADOW_OFFSET, offset_y + TEXT_SHADOW_OFFSET]);
+        unicode_text.text_colored([0.0, 0.0, 0.0, 0.5], &text);
+        ui.set_cursor_pos([offset_x, offset_y]);
+        unicode_text.text(&text);
+
+        let mut current_y = offset_y + ui.text_line_height_with_spacing();
 
         match &bomb_state.state {
             PlantedC4State::Active { time_detonation } => {
-                ui.set_cursor_pos_x(offset_x);
-                ui.text(&format!("Time: {:.3}", time_detonation));
+                // Time text
+                let time_text = format!("Time: {:.3}", time_detonation);
+                ui.set_cursor_pos([offset_x + TEXT_SHADOW_OFFSET, current_y + TEXT_SHADOW_OFFSET]);
+                unicode_text.text_colored([0.0, 0.0, 0.0, 0.5], &time_text);
+                ui.set_cursor_pos([offset_x, current_y]);
+                unicode_text.text(&time_text);
+                
+                current_y += ui.text_line_height_with_spacing();
+
                 if let Some(defuser) = &bomb_state.defuser {
                     let color = if defuser.time_remaining > *time_detonation {
                         [0.79, 0.11, 0.11, 1.0]
@@ -76,26 +89,35 @@ impl Enhancement for BombInfoIndicator {
                         [0.11, 0.79, 0.26, 1.0]
                     };
 
-                    ui.set_cursor_pos_x(offset_x);
-                    unicode_text.text_colored(
-                        color,
-                        &format!(
-                            "Defused in {:.3} by {}",
-                            defuser.time_remaining, defuser.player_name
-                        ),
+                    let defuse_text = format!(
+                        "Defused in {:.3} by {}",
+                        defuser.time_remaining, defuser.player_name
                     );
+                    ui.set_cursor_pos([offset_x + TEXT_SHADOW_OFFSET, current_y + TEXT_SHADOW_OFFSET]);
+                    unicode_text.text_colored([0.0, 0.0, 0.0, 0.5], &defuse_text);
+                    ui.set_cursor_pos([offset_x, current_y]);
+                    unicode_text.text_colored(color, &defuse_text);
                 } else {
-                    ui.set_cursor_pos_x(offset_x);
-                    ui.text("Not defusing");
+                    let not_defusing_text = "Not defusing";
+                    ui.set_cursor_pos([offset_x + TEXT_SHADOW_OFFSET, current_y + TEXT_SHADOW_OFFSET]);
+                    unicode_text.text_colored([0.0, 0.0, 0.0, 0.5], not_defusing_text);
+                    ui.set_cursor_pos([offset_x, current_y]);
+                    unicode_text.text(not_defusing_text);
                 }
             }
             PlantedC4State::Defused => {
-                ui.set_cursor_pos_x(offset_x);
-                ui.text("Bomb has been defused");
+                let text = "Bomb has been defused";
+                ui.set_cursor_pos([offset_x + TEXT_SHADOW_OFFSET, current_y + TEXT_SHADOW_OFFSET]);
+                unicode_text.text_colored([0.0, 0.0, 0.0, 0.5], text);
+                ui.set_cursor_pos([offset_x, current_y]);
+                unicode_text.text(text);
             }
             PlantedC4State::Detonated => {
-                ui.set_cursor_pos_x(offset_x);
-                ui.text("Bomb has been detonated");
+                let text = "Bomb has been detonated";
+                ui.set_cursor_pos([offset_x + TEXT_SHADOW_OFFSET, current_y + TEXT_SHADOW_OFFSET]);
+                unicode_text.text_colored([0.0, 0.0, 0.0, 0.5], text);
+                ui.set_cursor_pos([offset_x, current_y]);
+                unicode_text.text(text);
             }
             PlantedC4State::NotPlanted => unreachable!(),
         }

--- a/controller/src/enhancements/bomb.rs
+++ b/controller/src/enhancements/bomb.rs
@@ -4,10 +4,15 @@ use cs2::{
 };
 use imgui::ImColor32;
 use overlay::UnicodeTextRenderer;
-use crate::utils::{TextWithShadowUi, UnicodeTextWithShadowUi};
 
 use super::Enhancement;
-use crate::settings::AppSettings;
+use crate::{
+    settings::AppSettings,
+    utils::{
+        TextWithShadowUi,
+        UnicodeTextWithShadowUi,
+    },
+};
 pub struct BombInfoIndicator {}
 
 impl BombInfoIndicator {

--- a/controller/src/enhancements/player/info_layout.rs
+++ b/controller/src/enhancements/player/info_layout.rs
@@ -1,4 +1,5 @@
 use imgui::ImColor32;
+use crate::constants::TEXT_SHADOW_OFFSET;
 
 pub struct PlayerInfoLayout<'a> {
     ui: &'a imgui::Ui,
@@ -56,6 +57,15 @@ impl<'a> PlayerInfoLayout<'a> {
         pos.y += self.line_count as f32 * self.font_scale * (self.ui.text_line_height())
             + 4.0 * self.line_count as f32;
 
+        // Draw shadow first
+        let shadow_color = ImColor32::from_rgba(0, 0, 0, 180);
+        self.draw.add_text(
+            [pos.x + TEXT_SHADOW_OFFSET, pos.y + TEXT_SHADOW_OFFSET],
+            shadow_color,
+            text
+        );
+
+        // Draw main text
         self.draw.add_text([pos.x, pos.y], color, text);
         self.line_count += 1;
     }

--- a/controller/src/enhancements/player/info_layout.rs
+++ b/controller/src/enhancements/player/info_layout.rs
@@ -1,4 +1,8 @@
-use imgui::{ImColor32, DrawListMut};
+use imgui::{
+    DrawListMut,
+    ImColor32,
+};
+
 use crate::utils::TextWithShadowDrawList;
 
 pub struct PlayerInfoLayout<'a> {

--- a/controller/src/enhancements/player/info_layout.rs
+++ b/controller/src/enhancements/player/info_layout.rs
@@ -1,9 +1,9 @@
-use imgui::ImColor32;
-use crate::constants::TEXT_SHADOW_OFFSET;
+use imgui::{ImColor32, DrawListMut};
+use crate::utils::TextWithShadowDrawList;
 
 pub struct PlayerInfoLayout<'a> {
     ui: &'a imgui::Ui,
-    draw: &'a imgui::DrawListMut<'a>,
+    draw: &'a DrawListMut<'a>,
 
     vmin: nalgebra::Vector2<f32>,
     vmax: nalgebra::Vector2<f32>,
@@ -17,7 +17,7 @@ pub struct PlayerInfoLayout<'a> {
 impl<'a> PlayerInfoLayout<'a> {
     pub fn new(
         ui: &'a imgui::Ui,
-        draw: &'a imgui::DrawListMut<'a>,
+        draw: &'a DrawListMut<'a>,
         screen_bounds: mint::Vector2<f32>,
         vmin: nalgebra::Vector2<f32>,
         vmax: nalgebra::Vector2<f32>,
@@ -54,19 +54,11 @@ impl<'a> PlayerInfoLayout<'a> {
             pos.x -= text_width / 2.0;
             pos
         };
+
         pos.y += self.line_count as f32 * self.font_scale * (self.ui.text_line_height())
             + 4.0 * self.line_count as f32;
 
-        // Draw shadow first
-        let shadow_color = ImColor32::from_rgba(0, 0, 0, 180);
-        self.draw.add_text(
-            [pos.x + TEXT_SHADOW_OFFSET, pos.y + TEXT_SHADOW_OFFSET],
-            shadow_color,
-            text
-        );
-
-        // Draw main text
-        self.draw.add_text([pos.x, pos.y], color, text);
+        self.draw.add_text_with_shadow([pos.x, pos.y], color, text);
         self.line_count += 1;
     }
 }

--- a/controller/src/enhancements/spectators_list.rs
+++ b/controller/src/enhancements/spectators_list.rs
@@ -3,10 +3,12 @@ use cs2::{
     SpectatorList,
 };
 use overlay::UnicodeTextRenderer;
-use crate::utils::UnicodeTextWithShadowUi;
 
 use super::Enhancement;
-use crate::settings::AppSettings;
+use crate::{
+    settings::AppSettings,
+    utils::UnicodeTextWithShadowUi,
+};
 
 pub struct SpectatorsListIndicator;
 impl SpectatorsListIndicator {

--- a/controller/src/enhancements/spectators_list.rs
+++ b/controller/src/enhancements/spectators_list.rs
@@ -6,6 +6,7 @@ use overlay::UnicodeTextRenderer;
 
 use super::Enhancement;
 use crate::settings::AppSettings;
+use crate::constants::TEXT_SHADOW_OFFSET;
 
 pub struct SpectatorsListIndicator;
 impl SpectatorsListIndicator {
@@ -47,8 +48,14 @@ impl Enhancement for SpectatorsListIndicator {
         let mut offset_y = offset_y;
 
         for spectator in &spectators.spectators {
+            // Draw shadow text first
+            ui.set_cursor_pos([offset_x + TEXT_SHADOW_OFFSET, offset_y + TEXT_SHADOW_OFFSET]);
+            unicode_text.text_colored([0.0, 0.0, 0.0, 0.5], &spectator.spectator_name);
+
+            // Draw main text
             ui.set_cursor_pos([offset_x, offset_y]);
             unicode_text.text(&spectator.spectator_name);
+            
             offset_y += ui.text_line_height_with_spacing();
         }
 

--- a/controller/src/enhancements/spectators_list.rs
+++ b/controller/src/enhancements/spectators_list.rs
@@ -3,10 +3,10 @@ use cs2::{
     SpectatorList,
 };
 use overlay::UnicodeTextRenderer;
+use crate::utils::UnicodeTextWithShadowUi;
 
 use super::Enhancement;
 use crate::settings::AppSettings;
-use crate::constants::TEXT_SHADOW_OFFSET;
 
 pub struct SpectatorsListIndicator;
 impl SpectatorsListIndicator {
@@ -48,14 +48,8 @@ impl Enhancement for SpectatorsListIndicator {
         let mut offset_y = offset_y;
 
         for spectator in &spectators.spectators {
-            // Draw shadow text first
-            ui.set_cursor_pos([offset_x + TEXT_SHADOW_OFFSET, offset_y + TEXT_SHADOW_OFFSET]);
-            unicode_text.text_colored([0.0, 0.0, 0.0, 0.5], &spectator.spectator_name);
-
-            // Draw main text
             ui.set_cursor_pos([offset_x, offset_y]);
-            unicode_text.text(&spectator.spectator_name);
-            
+            ui.unicode_text_with_shadow(unicode_text, &spectator.spectator_name);
             offset_y += ui.text_line_height_with_spacing();
         }
 

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -84,6 +84,7 @@ mod settings;
 mod utils;
 mod view;
 mod winver;
+mod constants;
 
 pub trait MetricsClient {
     fn add_metrics_record(&self, record_type: &str, record_payload: &str);

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -75,6 +75,7 @@ use crate::{
     },
     settings::save_app_settings,
     winver::version_info,
+    utils::TextWithShadowUi,
 };
 
 mod dialog;
@@ -300,7 +301,7 @@ impl Application {
                     ui.window_size()[0] - ui.calc_text_size(text)[0] - 10.0,
                     10.0,
                 ]);
-                ui.text(text);
+                ui.text_with_shadow(text);
             }
             {
                 let text = format!("{:.2} FPS", ui.io().framerate);
@@ -308,7 +309,7 @@ impl Application {
                     ui.window_size()[0] - ui.calc_text_size(&text)[0] - 10.0,
                     24.0,
                 ]);
-                ui.text(text)
+                ui.text_with_shadow(&text)
             }
             {
                 let text = format!("{} Reads", self.frame_read_calls);
@@ -316,7 +317,7 @@ impl Application {
                     ui.window_size()[0] - ui.calc_text_size(&text)[0] - 10.0,
                     38.0,
                 ]);
-                ui.text(text)
+                ui.text_with_shadow(&text)
             }
         }
 

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -74,8 +74,8 @@ use crate::{
         TriggerBot,
     },
     settings::save_app_settings,
-    winver::version_info,
     utils::TextWithShadowUi,
+    winver::version_info,
 };
 
 mod dialog;

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -84,7 +84,6 @@ mod settings;
 mod utils;
 mod view;
 mod winver;
-mod constants;
 
 pub trait MetricsClient {
     fn add_metrics_record(&self, record_type: &str, record_payload: &str);

--- a/controller/src/utils/imgui.rs
+++ b/controller/src/utils/imgui.rs
@@ -1,6 +1,113 @@
 use std::borrow::Cow;
-
+use imgui::{ImColor32, DrawListMut};
 use crate::settings::HotKey;
+use crate::UnicodeTextRenderer;
+
+const TEXT_SHADOW_OFFSET: f32 = 1.0;
+const TEXT_SHADOW_COLOR: [f32; 4] = [0.0, 0.0, 0.0, 0.7];
+
+pub trait TextWithShadowDrawList {
+    fn add_text_with_shadow(&self, pos: [f32; 2], color: impl Into<ImColor32>, text: &str);
+}
+
+impl TextWithShadowDrawList for DrawListMut<'_> {
+    fn add_text_with_shadow(&self, pos: [f32; 2], color: impl Into<ImColor32>, text: &str) {
+        self.add_text(
+            [pos[0] + TEXT_SHADOW_OFFSET, pos[1] + TEXT_SHADOW_OFFSET],
+            TEXT_SHADOW_COLOR,
+            text,
+        );
+
+        self.add_text([pos[0], pos[1]], color, text);
+    }
+}
+
+pub trait TextWithShadowUi {
+    fn text_with_shadow(&self, text: &str);
+    fn text_colored_with_shadow(&self, color: impl Into<ImColor32>, text: &str);
+}
+
+impl TextWithShadowUi for imgui::Ui {
+    fn text_with_shadow(&self, text: &str) {
+        let pos = self.cursor_pos();
+
+        self.set_cursor_pos([pos[0] + TEXT_SHADOW_OFFSET, pos[1] + TEXT_SHADOW_OFFSET]);
+        self.text_colored(TEXT_SHADOW_COLOR, text);
+
+        self.set_cursor_pos(pos);
+        self.text(text);
+    }
+
+    fn text_colored_with_shadow(&self, color: impl Into<ImColor32>, text: &str, ) {
+        let pos = self.cursor_pos();
+        let color = color.into();
+        let color_vec = [
+            color.r as f32 / 255.0,
+            color.g as f32 / 255.0,
+            color.b as f32 / 255.0,
+            color.a as f32 / 255.0,
+        ];
+
+        self.set_cursor_pos([pos[0] + TEXT_SHADOW_OFFSET, pos[1] + TEXT_SHADOW_OFFSET]);
+        self.text_colored(TEXT_SHADOW_COLOR, text);
+
+        self.set_cursor_pos(pos);
+        self.text_colored(color_vec, text);
+    }
+}
+
+pub trait UnicodeTextWithShadowUi {
+    fn unicode_text_with_shadow(
+        &self,
+        unicode_text: &UnicodeTextRenderer,
+        text: &str,
+    );
+
+    fn unicode_text_colored_with_shadow(
+        &self,
+        unicode_text: &UnicodeTextRenderer,
+        color: impl Into<ImColor32>,
+        text: &str,
+    );    
+}
+
+impl UnicodeTextWithShadowUi for imgui::Ui {
+    fn unicode_text_with_shadow(
+        &self,
+        unicode_text: &UnicodeTextRenderer,
+        text: &str,
+    ) {
+        let pos = self.cursor_pos();
+
+        self.set_cursor_pos([pos[0] + TEXT_SHADOW_OFFSET, pos[1] + TEXT_SHADOW_OFFSET]);
+        unicode_text.text_colored(TEXT_SHADOW_COLOR, text);
+
+        self.set_cursor_pos(pos);
+        unicode_text.text(text);
+    }
+
+    fn unicode_text_colored_with_shadow(
+        &self,
+        unicode_text: &UnicodeTextRenderer,
+        color: impl Into<ImColor32>,
+        text: &str,
+    ) {
+        let pos = self.cursor_pos();
+        let color = color.into();
+        let color_vec = [
+            color.r as f32 / 255.0,
+            color.g as f32 / 255.0,
+            color.b as f32 / 255.0,
+            color.a as f32 / 255.0,
+        ];
+
+        self.set_cursor_pos([pos[0] + TEXT_SHADOW_OFFSET, pos[1] + TEXT_SHADOW_OFFSET]);
+        unicode_text.text_colored(TEXT_SHADOW_COLOR, text);
+
+        self.set_cursor_pos(pos);
+        unicode_text.text_colored(color_vec, text);
+    }
+}
 
 pub trait ImguiUiEx {
     fn set_cursor_pos_x(&self, pos: f32);

--- a/controller/src/utils/imgui.rs
+++ b/controller/src/utils/imgui.rs
@@ -1,7 +1,14 @@
 use std::borrow::Cow;
-use imgui::{ImColor32, DrawListMut};
-use crate::settings::HotKey;
-use crate::UnicodeTextRenderer;
+
+use imgui::{
+    DrawListMut,
+    ImColor32,
+};
+
+use crate::{
+    settings::HotKey,
+    UnicodeTextRenderer,
+};
 
 const TEXT_SHADOW_OFFSET: f32 = 1.0;
 const TEXT_SHADOW_COLOR: [f32; 4] = [0.0, 0.0, 0.0, 0.7];
@@ -38,7 +45,7 @@ impl TextWithShadowUi for imgui::Ui {
         self.text(text);
     }
 
-    fn text_colored_with_shadow(&self, color: impl Into<ImColor32>, text: &str, ) {
+    fn text_colored_with_shadow(&self, color: impl Into<ImColor32>, text: &str) {
         let pos = self.cursor_pos();
         let color = color.into();
         let color_vec = [
@@ -57,26 +64,18 @@ impl TextWithShadowUi for imgui::Ui {
 }
 
 pub trait UnicodeTextWithShadowUi {
-    fn unicode_text_with_shadow(
-        &self,
-        unicode_text: &UnicodeTextRenderer,
-        text: &str,
-    );
+    fn unicode_text_with_shadow(&self, unicode_text: &UnicodeTextRenderer, text: &str);
 
     fn unicode_text_colored_with_shadow(
         &self,
         unicode_text: &UnicodeTextRenderer,
         color: impl Into<ImColor32>,
         text: &str,
-    );    
+    );
 }
 
 impl UnicodeTextWithShadowUi for imgui::Ui {
-    fn unicode_text_with_shadow(
-        &self,
-        unicode_text: &UnicodeTextRenderer,
-        text: &str,
-    ) {
+    fn unicode_text_with_shadow(&self, unicode_text: &UnicodeTextRenderer, text: &str) {
         let pos = self.cursor_pos();
 
         self.set_cursor_pos([pos[0] + TEXT_SHADOW_OFFSET, pos[1] + TEXT_SHADOW_OFFSET]);


### PR DESCRIPTION
Added text shadow effects to improve readability of overlay text elements across different background colors. The changes include:

- Added shadow effects to player info layout text
- Added shadow effects to bomb info text
- Added shadow effects to spectators list text
- Shadow color is black with 50% opacity

These changes make the text more readable when displayed over varying background colors and brightness levels in-game.

Preview:
![411187424-f0e04ca2-2bc1-4423-83e1-8aa1dd370805](https://github.com/user-attachments/assets/9d1fdee8-6e1b-4e64-a35c-07cb133f8a83)
