### PR TITLE
Feature - Add sniper rifles crosshair overlay

### DIFF
--- a/controller/src/enhancements/mod.rs
+++ b/controller/src/enhancements/mod.rs
@@ -44,6 +44,9 @@ pub use aim::*;
 
 mod grenade_helper;
 pub use grenade_helper::*;
+
+pub mod sniper_crosshair;
+
 use utils_state::StateRegistry;
 
 use crate::UpdateContext;

--- a/controller/src/enhancements/sniper_crosshair.rs
+++ b/controller/src/enhancements/sniper_crosshair.rs
@@ -1,0 +1,99 @@
+use cs2::{StateCS2Memory, StateEntityList, StateLocalPlayerController};
+use cs2_schema_generated::cs2::client::{C_CSPlayerPawnBase, C_EconEntity};
+use overlay::UnicodeTextRenderer;
+use utils_state::StateRegistry;
+
+use super::Enhancement;
+use crate::settings::AppSettings;
+
+pub struct SniperCrosshair;
+
+impl SniperCrosshair {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn is_sniper_weapon(&self, weapon_id: u16) -> bool {
+        // AWP = 9, SSG08 = 40, SCAR-20 = 38, G3SG1 = 11
+        matches!(weapon_id, 9 | 40 | 38 | 11)
+    }
+}
+
+impl Enhancement for SniperCrosshair {
+    fn update(&mut self, _ctx: &crate::UpdateContext) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn render(
+        &self,
+        states: &StateRegistry,
+        ui: &imgui::Ui,
+        _unicode_text: &UnicodeTextRenderer,
+    ) -> anyhow::Result<()> {
+        let settings = states.resolve::<AppSettings>(())?;
+        if !settings.sniper_crosshair {
+            return Ok(());
+        }
+
+        let memory = states.resolve::<StateCS2Memory>(())?;
+        let local_controller = states.resolve::<StateLocalPlayerController>(())?;
+        let view = states.resolve::<crate::view::ViewController>(())?;
+        
+        // Get local player pawn
+        let local_pawn = match local_controller.instance.value_reference(memory.view_arc()) {
+            Some(controller) => {
+                let entities = states.resolve::<StateEntityList>(())?;
+                match entities.entity_from_handle(&controller.m_hPlayerPawn()?) {
+                    Some(pawn) => pawn.value_reference(memory.view_arc())
+                        .ok_or_else(|| anyhow::anyhow!("pawn nullptr"))?,
+                    None => return Ok(()),
+                }
+            }
+            None => return Ok(()),
+        };
+
+        // Get active weapon
+        let weapon = local_pawn.m_pClippingWeapon()?
+            .value_reference(memory.view_arc())
+            .ok_or_else(|| anyhow::anyhow!("weapon nullptr"))?
+            .cast::<dyn C_EconEntity>();
+
+        // Get weapon info through attribute manager
+        let weapon_id = weapon
+            .m_AttributeManager()?
+            .m_Item()?
+            .m_iItemDefinitionIndex()?;
+
+        // Check if it's a sniper rifle
+        if !self.is_sniper_weapon(weapon_id) {
+            return Ok(());
+        }
+
+        let draw = ui.get_window_draw_list();
+        let screen_center = [
+            view.screen_bounds.x / 2.0,
+            view.screen_bounds.y / 2.0,
+        ];
+
+        // Draw shadow (black outline)
+        draw.add_circle(screen_center, 3.5, [0.0, 0.0, 0.0, 0.8])
+            .filled(true)
+            .build();
+
+        // Draw white dot
+        draw.add_circle(screen_center, 2.0, [1.0, 1.0, 1.0, 0.8])
+            .filled(true)
+            .build();
+
+        Ok(())
+    }
+
+    fn render_debug_window(
+        &mut self,
+        _states: &StateRegistry,
+        _ui: &imgui::Ui,
+        _unicode_text: &UnicodeTextRenderer,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+} 

--- a/controller/src/enhancements/sniper_crosshair.rs
+++ b/controller/src/enhancements/sniper_crosshair.rs
@@ -5,6 +5,7 @@ use cs2::{
     LocalCameraControllerTarget,
     StateCS2Memory,
     StateEntityList,
+    WeaponId,
 };
 use cs2_schema_generated::cs2::client::{
     C_CSObserverPawn,
@@ -26,8 +27,10 @@ impl SniperCrosshair {
     }
 
     fn is_sniper_weapon(&self, weapon_id: u16) -> bool {
-        // AWP = 9, SSG08 = 40, SCAR-20 = 38, G3SG1 = 11
-        matches!(weapon_id, 9 | 40 | 38 | 11)
+        matches!(
+            WeaponId::from_id(weapon_id).unwrap_or(WeaponId::Unknown),
+            WeaponId::AWP | WeaponId::Ssg08 | WeaponId::Scar20 | WeaponId::G3SG1
+        )
     }
 
     fn get_active_weapon(

--- a/controller/src/enhancements/sniper_crosshair.rs
+++ b/controller/src/enhancements/sniper_crosshair.rs
@@ -53,15 +53,13 @@ impl SniperCrosshair {
                     .value_reference(memory.view_arc())
                     .context("player pawn nullptr")?;
 
-                let weapon = player_pawn
-                    .m_pClippingWeapon()?
-                    .value_reference(memory.view_arc())
-                    .ok_or_else(|| anyhow::anyhow!("weapon nullptr"))?
-                    .cast::<dyn C_EconEntity>();
+                let weapon_ref = match player_pawn.m_pClippingWeapon()?.value_reference(memory.view_arc()) {
+                    Some(weapon) => weapon,
+                    None => return Ok(None),
+                };
 
-                Ok(Some(
-                    weapon.m_AttributeManager()?.m_Item()?.m_iItemDefinitionIndex()?,
-                ))
+                let weapon = weapon_ref.cast::<dyn C_EconEntity>();
+                Ok(Some(weapon.m_AttributeManager()?.m_Item()?.m_iItemDefinitionIndex()?))
             }
             "C_CSObserverPawn" => {
                 // Handle observer pawn
@@ -87,16 +85,13 @@ impl SniperCrosshair {
                     .context("player pawn nullptr")?
                     .cast::<dyn C_CSPlayerPawnBase>();
 
-                // Get active weapon from the player pawn
-                let weapon = player_pawn
-                    .m_pClippingWeapon()?
-                    .value_reference(memory.view_arc())
-                    .ok_or_else(|| anyhow::anyhow!("weapon nullptr"))?
-                    .cast::<dyn C_EconEntity>();
+                let weapon_ref = match player_pawn.m_pClippingWeapon()?.value_reference(memory.view_arc()) {
+                    Some(weapon) => weapon,
+                    None => return Ok(None),
+                };
 
-                Ok(Some(
-                    weapon.m_AttributeManager()?.m_Item()?.m_iItemDefinitionIndex()?,
-                ))
+                let weapon = weapon_ref.cast::<dyn C_EconEntity>();
+                Ok(Some(weapon.m_AttributeManager()?.m_Item()?.m_iItemDefinitionIndex()?))
             }
             _ => Ok(None),
         }

--- a/controller/src/enhancements/sniper_crosshair.rs
+++ b/controller/src/enhancements/sniper_crosshair.rs
@@ -8,10 +8,10 @@ use cs2::{
     WeaponId,
 };
 use cs2_schema_generated::cs2::client::{
+    CBasePlayerController,
     C_CSObserverPawn,
     C_CSPlayerPawnBase,
     C_EconEntity,
-    CBasePlayerController,
 };
 use overlay::UnicodeTextRenderer;
 use utils_state::StateRegistry;
@@ -56,13 +56,21 @@ impl SniperCrosshair {
                     .value_reference(memory.view_arc())
                     .context("player pawn nullptr")?;
 
-                let weapon_ref = match player_pawn.m_pClippingWeapon()?.value_reference(memory.view_arc()) {
+                let weapon_ref = match player_pawn
+                    .m_pClippingWeapon()?
+                    .value_reference(memory.view_arc())
+                {
                     Some(weapon) => weapon,
                     None => return Ok(None),
                 };
 
                 let weapon = weapon_ref.cast::<dyn C_EconEntity>();
-                Ok(Some(weapon.m_AttributeManager()?.m_Item()?.m_iItemDefinitionIndex()?))
+                Ok(Some(
+                    weapon
+                        .m_AttributeManager()?
+                        .m_Item()?
+                        .m_iItemDefinitionIndex()?,
+                ))
             }
             "C_CSObserverPawn" => {
                 // Handle observer pawn
@@ -88,13 +96,21 @@ impl SniperCrosshair {
                     .context("player pawn nullptr")?
                     .cast::<dyn C_CSPlayerPawnBase>();
 
-                let weapon_ref = match player_pawn.m_pClippingWeapon()?.value_reference(memory.view_arc()) {
+                let weapon_ref = match player_pawn
+                    .m_pClippingWeapon()?
+                    .value_reference(memory.view_arc())
+                {
                     Some(weapon) => weapon,
                     None => return Ok(None),
                 };
 
                 let weapon = weapon_ref.cast::<dyn C_EconEntity>();
-                Ok(Some(weapon.m_AttributeManager()?.m_Item()?.m_iItemDefinitionIndex()?))
+                Ok(Some(
+                    weapon
+                        .m_AttributeManager()?
+                        .m_Item()?
+                        .m_iItemDefinitionIndex()?,
+                ))
             }
             _ => Ok(None),
         }
@@ -130,7 +146,12 @@ impl Enhancement for SniperCrosshair {
         };
 
         // Get weapon ID from either player pawn or observer pawn
-        let weapon_id = match self.get_active_weapon(&entities, &memory, &class_name_cache, target_entity_id)? {
+        let weapon_id = match self.get_active_weapon(
+            &entities,
+            &memory,
+            &class_name_cache,
+            target_entity_id,
+        )? {
             Some(id) => id,
             None => return Ok(()),
         };
@@ -141,10 +162,7 @@ impl Enhancement for SniperCrosshair {
         }
 
         let draw = ui.get_window_draw_list();
-        let screen_center = [
-            view.screen_bounds.x / 2.0,
-            view.screen_bounds.y / 2.0,
-        ];
+        let screen_center = [view.screen_bounds.x / 2.0, view.screen_bounds.y / 2.0];
 
         // Draw shadow (black outline)
         draw.add_circle(screen_center, 3.5, [0.0, 0.0, 0.0, 0.8])

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -72,6 +72,7 @@ use crate::{
         PlayerESP,
         SpectatorsListIndicator,
         TriggerBot,
+        sniper_crosshair::SniperCrosshair,
     },
     settings::save_app_settings,
     winver::version_info,
@@ -557,6 +558,7 @@ fn real_main(args: &AppArgs) -> anyhow::Result<()> {
             Rc::new(RefCell::new(BombInfoIndicator::new())),
             Rc::new(RefCell::new(TriggerBot::new())),
             Rc::new(RefCell::new(GrenadeHelper::new())),
+            Rc::new(RefCell::new(SniperCrosshair::new())),
         ],
 
         last_total_read_calls: 0,

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -67,12 +67,12 @@ use windows::Win32::UI::Shell::IsUserAnAdmin;
 
 use crate::{
     enhancements::{
+        sniper_crosshair::SniperCrosshair,
         AntiAimPunsh,
         BombInfoIndicator,
         PlayerESP,
         SpectatorsListIndicator,
         TriggerBot,
-        sniper_crosshair::SniperCrosshair,
     },
     settings::save_app_settings,
     winver::version_info,

--- a/controller/src/settings/config.rs
+++ b/controller/src/settings/config.rs
@@ -277,6 +277,9 @@ pub struct AppSettings {
     #[serde(default = "bool_false")]
     pub web_radar_advanced_settings: bool,
 
+    #[serde(default = "bool_false")]
+    pub sniper_crosshair: bool,
+
     #[serde(flatten, with = "serde_prefix_grenade_helper")]
     pub grenade_helper: GrenadeSettings,
 

--- a/controller/src/settings/ui.rs
+++ b/controller/src/settings/ui.rs
@@ -281,6 +281,7 @@ impl SettingsUI {
                         ui.checkbox(obfstr!("Bomb Timer"), &mut settings.bomb_timer);
                         ui.checkbox(obfstr!("Spectators List"), &mut settings.spectators_list);
                         ui.checkbox(obfstr!("Grenade Helper"), &mut settings.grenade_helper.active);
+                        ui.checkbox(obfstr!("Sniper Crosshair"), &mut settings.sniper_crosshair);
                     }
 
                     if let Some(_tab) = ui.tab_item(obfstr!("ESP")) {


### PR DESCRIPTION
A simple crosshair overlay that appears when using sniper rifles (AWP, SSG08, SCAR-20, G3SG1). 
The crosshair consists of a white dot with black outline for better visibility.

Details:
- Adds new `SniperCrosshair` enhancement
- Detects sniper rifles using weapon IDs (9=AWP, 40=SSG08, 38=SCAR-20, 11=G3SG1)
- Draws a centered crosshair dot with shadow outline
- Configurable via settings toggle
- Works in both normal play and spectator mode
- Minimal performance impact (uses existing weapon detection code)

This helps with quick-scoping and no-scope shots by providing a consistent center point reference.

Preview:
![image](https://github.com/user-attachments/assets/69854cea-03d6-4587-bdaa-29b62fb077f3)
![image](https://github.com/user-attachments/assets/781f495f-cbd9-4839-98c4-02ddc00226c7)
